### PR TITLE
update rxjs to version 6

### DIFF
--- a/lib/ov2500.js
+++ b/lib/ov2500.js
@@ -295,7 +295,7 @@ class OV {
     }
 
     getNotificationsWithRetry(ip) {
-        return Rx.Observable.fromPromise(new Promise((resolve, reject) => {
+        return Rx.from(new Promise((resolve, reject) => {
                 request.post({
                     url: this.url + '/api/notifications/alarms',
                     headers: this.headers,
@@ -318,7 +318,7 @@ class OV {
                     }
                 });
             })
-        ).retry(3)
+        ).retry(3);
     }
 
     getMacAddresses(ip) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "deep-diff": "^0.3.8",
     "moment-timezone": "^0.5.14",
     "request": "^2.83.0",
-    "rxjs": "^5.5.6"
+    "rxjs": "^6.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updates rxjs to version 6.

A review of the code indicates that no other parts are affected by the breaking changes in the library update.